### PR TITLE
Implemented mass AutoRenew feature, set when bot stops and clear when…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ gaptop = 200
 #If set to 0 all offers will be placed for a 2 day period
 sixtydaythreshold = 0.2
 
+# AutoRenew - if set to 1 the bot will set the AutoRenew flag for the loans when you stop it (Ctrl+C) and clear the AutoRenew flag when on started
+autorenew = 0
+
 #custom config per coin, useful when closing positions etc.
 #syntax: ["COIN:mindailyrate:maxactiveamount",...]
 #if maxactive amount is 0 - stop lending this coin. in the future you'll be able to limit amount to be lent.
@@ -61,6 +64,9 @@ sixtydaythreshold = 0.2
 ```
 
 If `spreadlend = 1` and `gapbottom = 0`, it will behave as simple lending bot lending at lowest possible offer.
+
+## Command Line Parameters
+--clearAutoRenew - will clear the AutoRenew flag on all exising loans
 
 ##Donations
 

--- a/poloniex.py
+++ b/poloniex.py
@@ -154,3 +154,7 @@ class Poloniex:
 
     def returnLoanOrders(self,currency):
         return self.api_query('returnLoanOrders',{"currency":currency})
+
+    # Toggles the auto renew setting for the specified orderNumber
+    def toggleAutoRenew(self, orderNumber):
+        return self.api_query('toggleAutoRenew',{"orderNumber":orderNumber})


### PR DESCRIPTION
Added ability to automatically switch Active Loans AutoRenew flag when it shuts down and clear the AutoRenew flag when it starts.
Useful if you can't keep the bot running for some reason.
The --clearAutoRenew command line parameter is useful if you want to stop loaning completely.

Both abilities are disabled by default.