### PR TITLE
Matching returnOpenLoanOffers to the API

### DIFF
--- a/lendingbot.py
+++ b/lendingbot.py
@@ -162,7 +162,7 @@ def createLoanOffer(cur,amt,rate):
 			log.offer(amt, cur, rate, days, msg)
 
 def cancelAndLoanAll():
-	loanOffers = bot.returnOpenLoanOffers('BTC') #some bug with api wrapper? no idea why I have to provide a currency, and then receive every other
+	loanOffers = bot.returnOpenLoanOffers()
 	if type(loanOffers) is list: #silly api wrapper, empty dict returns a list, which brakes the code later.
 		loanOffers = {}
 	if loanOffers.get('error'):

--- a/poloniex.py
+++ b/poloniex.py
@@ -89,8 +89,8 @@ class Poloniex:
     def returnOpenOrders(self,currencyPair):
         return self.api_query('returnOpenOrders',{"currencyPair":currencyPair})
 
-    def returnOpenLoanOffers(self,currency):
-        return self.api_query('returnOpenLoanOffers',{"currency":currency})
+    def returnOpenLoanOffers(self):
+        return self.api_query('returnOpenLoanOffers')
 
     def returnActiveLoans(self):
         return self.api_query('returnActiveLoans')


### PR DESCRIPTION
returnOpenLoanOffers doesn't have any arguments.
Fixes Issue #54 