### PR TITLE
Catch exception when attempting to cancel loan offer

### DIFF
--- a/lendingbot.py
+++ b/lendingbot.py
@@ -287,8 +287,11 @@ def cancelAndLoanAll():
 		for offer in loanOffers[cur]:
 			onOrderBalances[cur] = onOrderBalances.get(cur, 0) + Decimal(offer['amount'])
 			if dryRun == False:
-				msg = bot.cancelLoanOffer(cur,offer['id'])
-				log.cancelOrders(cur, msg)
+				try:
+					msg = bot.cancelLoanOffer(cur,offer['id'])
+					log.cancelOrders(cur, msg)
+				except Exception as e:
+					log.log("Error canceling loan offer: " + str(e))
 
 	lendingBalances = bot.returnAvailableAccountBalances("lending")['lending']
 	if dryRun == True: #just fake some numbers, if dryrun (testing)


### PR DESCRIPTION
If a loan offer is taken some time in between the "returnOpenLoanOffers" and "cancelLoanOffer" calls, the attempt to cancel the order will raise an error since it's already taken.

When this happens, the uncaught exception propagates to the main loop and causes the bot to not lend out its funds for as long as sleepTime.

This issue will be more likely to occur the higher the "spreadLend" parameter is.

<pre>
2016-09-08 15:56:21 Canceling all BTC orders... Loan offer canceled.
2016-09-08 15:56:22 Canceling all BTC orders... Loan offer canceled.
2016-09-08 15:56:22 Canceling all BTC orders... Loan offer canceled.
2016-09-08 15:56:22 Canceling all BTC orders... Loan offer canceled.
2016-09-08 15:56:23 ERROR: Error canceling loan order, or you are not the person who placed it.
Traceback (most recent call last):
  File "lendingbot.py", line 461, in <module>
    cancelAndLoanAll()
  File "lendingbot.py", line 290, in cancelAndLoanAll
    msg = bot.cancelLoanOffer(cur,offer['id'])
  File "/home/scrawl/Dev/poloniexlendingbot/poloniex.py", line 157, in cancelLoanOffer
    return self.api_query('cancelLoanOffer',{"currency":currency,"orderNumber":orderNumber})
  File "/home/scrawl/Dev/poloniexlendingbot/poloniex.py", line 68, in api_query
    jsonRet = _read_response(ret)
  File "/home/scrawl/Dev/poloniexlendingbot/poloniex.py", line 38, in _read_response
    raise PoloniexApiError(data['error'])
PoloniexApiError: Error canceling loan order, or you are not the person who placed it.
</pre>

The fix is to catch exceptions when attempting to cancel orders, and assume the order is already filled if the cancellation fails.

<pre>
2016-09-08 16:01:38 Canceling all BTC orders... Loan offer canceled.
2016-09-08 16:01:38 Canceling all BTC orders... Loan offer canceled.
2016-09-08 16:01:39 Canceling all BTC orders... Loan offer canceled.
2016-09-08 16:01:39 Canceling all BTC orders... Loan offer canceled.
2016-09-08 16:01:40 Error canceling loan offer: Error canceling loan order, or you are not the person who placed it.
2016-09-08 16:01:41 Placing X BTC at Y% for 2 days... Loan order placed.
2016-09-08 16:01:44 Placing X BTC at Y% for 2 days... Loan order placed.
2016-09-08 16:01:44 Placing X BTC at Y% for 2 days... Loan order placed.
2016-09-08 16:01:45 Placing X BTC at Y% for 2 days... Loan order placed.
</pre>