### PR TITLE
Max to lent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 default.cfg
 www/botlog.json
 nohup.out
+error.log

--- a/Logger.py
+++ b/Logger.py
@@ -64,7 +64,11 @@ class JsonOutput(object):
 	def clearStatusValues(self):
 		self.jsonOutputCoins = {}
 		self.jsonOutput["raw_data"] = self.jsonOutputCoins
+		self.jsonOutputCurrency = {}
+		self.jsonOutput["outputCurrency"] = self.jsonOutputCurrency
 
+	def outputCurrency(self, key, value):
+                self.jsonOutputCurrency[key] = str(value)
 
 class Logger(object):
 	def __init__(self, jsonFile = '', jsonLogSize = -1):
@@ -101,6 +105,10 @@ class Logger(object):
 	def updateStatusValue(self, coin, key, value):
 		if(hasattr(self.console , 'statusValue')):
 			self.console.statusValue(coin, key, value)
+
+        def updateOutputCurrency(self, key, value):
+		if(hasattr(self.console , 'outputCurrency')):
+			self.console.outputCurrency(key, value)
 	
 	def persistStatus(self):
 		if(hasattr(self.console , 'writeJsonFile')):

--- a/README.md
+++ b/README.md
@@ -70,10 +70,17 @@ minloansize = 0.001
 #AutoRenew - if set to 1 the bot will set the AutoRenew flag for the loans when you stop it (Ctrl+C) and clear the AutoRenew flag when on started
 autorenew = 0
 
-#custom config per coin, useful when closing positions etc.
-#syntax: ["COIN:mindailyrate:maxactiveamount",...]
+#Max amount to lent. if set to 0 or commented the bot will check for maxpercenttolent.
+#maxtolent = 0
+
+#Max percent to lent. if set to 0 or commented the bot will lent the 100%.
+#maxpercenttolent = 0
+
+#syntax: ["COIN:mindailyrate:maxactiveamount:maxtolent:maxpercenttolent",...]
 #if maxactive amount is 0 - stop lending this coin. in the future you'll be able to limit amount to be lent.
-#coinconfig = ["BTC:0.18:1","CLAM:0.6:1"]
+#if maxtolent is 0 - check for maxpercenttolent.
+#if maxpercenttolent is 0 - 100% is going to be lent.
+#coinconfig = ["BTC:0.18:1:0:0","CLAM:0.6:1:0:0"]
 
 #this option creates a json log file instead of console output which includes the most recent status
 #uncomment both jsonfile and jsonlogsize to enable

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ autorenew = 0
 #jsonlogsize = 200
 #enables a webserver for the www folder, in order to easily use the lendingbot.html with the json log
 #startWebServer = true
+
+# Calculate the Account Estimated Earnings on BTC or in USD. if true = BTC, if false = USD
+CalculateOnBTC = true
 ```
 
 If `spreadlend = 1` and `gapbottom = 0`, it will behave as simple lending bot lending at lowest possible offer.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ autorenew = 0
 #enables a webserver for the www folder, in order to easily use the lendingbot.html with the json log
 #startWebServer = true
 
-# Calculate the Account Estimated Earnings on BTC or in USD. if true = BTC, if false = USD
-CalculateOnBTC = true
+#The currency that the HTML Overview will present the earnings summary in.
+#Options are BTC, USDT, ETH or anything as long as it has a direct BTC market. The default is BTC.
+#outputCurrency = BTC
 ```
 
 If `spreadlend = 1` and `gapbottom = 0`, it will behave as simple lending bot lending at lowest possible offer.

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -412,7 +412,7 @@ def cancelAndLoanAll():
 		if activeCur in totalLended:
 			activePlusLended += Decimal(totalLended[activeCur])
 		#log total coin
-		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur]))
+		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur])))
 		if loansLength == 0:
 			createLoanOffer(activeCur,Decimal(activeBal)-lent,maxDailyRate)
 		for offer in loans['offers']:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -326,7 +326,11 @@ def createLoanOffer(cur,amt,rate):
 loanOrdersRequestLimit = {}
 defaultLoanOrdersRequestLimit = 200
 
-def amountToLent(activeCurTestBalance,activeCur,lendingBalance):
+def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
+	if activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] != 0:
+		print("Low Rate "+str(lowrate)+" vs conditional rate"+str(coincfg[activeCur]['maxtolentrate']))
+	if(activeCur not in coincfg and maxtolentrate != 0):
+		print("Low Rate "+str(lowrate)+" vs conditional rate"+str(coincfg[activeCur]['maxtolentrate']))
 	activeBal = Decimal(0)
 	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0:
 		log.updateStatusValue(activeCur, "maxToLend", coincfg[activeCur]['maxtolent'])
@@ -380,7 +384,7 @@ def cancelAndLoanAll():
 	#Fill the (maxToLend) balances on the botlog.json for display it on the web
 	for key in sorted(totalLended):
 		if(len(lendingBalances) == 0 or key not in lendingBalances):
-			amountToLent(totalLended[key],key,0)
+			amountToLent(totalLended[key],key,0,0)
 	
 	activeCurIndex = 0
 	usableCurrencies = 0
@@ -414,11 +418,7 @@ def cancelAndLoanAll():
 		loans = bot.returnLoanOrders(activeCur, loanOrdersRequestLimit[activeCur] )
 		loansLength = len(loans['offers'])
 		
-		#for offer in loans['offers']:
-		#	print(offer['rate'])
-		print(loans['offers'][0]['rate'])
-		
-		activeBal = amountToLent(activeCurTestBalance,activeCur,Decimal(lendingBalances[activeCur]))
+		activeBal = amountToLent(activeCurTestBalance,activeCur,Decimal(lendingBalances[activeCur]),Decimal(loans['offers'][0]['rate']))
 		
 		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
 			usableCurrencies = 1

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,11 +329,11 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
-		if(Decimal(lowrate) > 0)
+		if(lowrate != 0)
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
 	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
-		if(Decimal(lowrate) > 0)
+		if(lowrate != 0)
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -328,12 +328,10 @@ defaultLoanOrdersRequestLimit = 200
 
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
-	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
-		if(lowrate != 0)
+	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
-	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
-		if(lowrate != 0)
+	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -327,27 +327,30 @@ loanOrdersRequestLimit = {}
 defaultLoanOrdersRequestLimit = 200
 
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
-	if activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] != 0:
-		print("Low Rate "+str(lowrate)+" vs conditional rate"+str(coincfg[activeCur]['maxtolentrate']))
-	if(activeCur not in coincfg and maxtolentrate != 0):
-		print("Low Rate "+str(lowrate)+" vs conditional rate"+str(coincfg[activeCur]['maxtolentrate']))
+	restrictLent = False
+	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 and lowrate <= coincfg[activeCur]['maxtolentrate']):
+		log.log("Low Rate "+str(lowrate)+" vs conditional rate "+str(coincfg[activeCur]['maxtolentrate']))
+		restrictLent = True
+	if(activeCur not in coincfg and maxtolentrate == 0 and lowrate <= maxtolentrate):
+		log.log("Low Rate "+str(lowrate)+" vs conditional rate "+str(maxtolentrate))
+		restrictLent = True
 	activeBal = Decimal(0)
-	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0:
+	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:
 		log.updateStatusValue(activeCur, "maxToLend", coincfg[activeCur]['maxtolent'])
                 if(lendingBalance > (activeCurTestBalance - coincfg[activeCur]['maxtolent'])):
 			activeBal = (lendingBalance - (activeCurTestBalance - coincfg[activeCur]['maxtolent']))
-        if activeCur in coincfg and coincfg[activeCur]['maxtolent'] == 0 and coincfg[activeCur]['maxpercenttolent'] != 0:
+        if activeCur in coincfg and coincfg[activeCur]['maxtolent'] == 0 and coincfg[activeCur]['maxpercenttolent'] != 0 and restrictLent == True:
 		log.updateStatusValue(activeCur, "maxToLend", (coincfg[activeCur]['maxpercenttolent'] * activeCurTestBalance))
                 if(lendingBalance > (activeCurTestBalance - (coincfg[activeCur]['maxpercenttolent'] * activeCurTestBalance))):
 			activeBal = (lendingBalance - (activeCurTestBalance - (coincfg[activeCur]['maxpercenttolent'] * activeCurTestBalance)))
         if activeCur in coincfg and coincfg[activeCur]['maxtolent'] == 0 and coincfg[activeCur]['maxpercenttolent'] == 0:
 		log.updateStatusValue(activeCur, "maxToLend", activeCurTestBalance)
 		activeBal = lendingBalance
-	if(activeCur not in coincfg and maxtolent != 0):
+	if(activeCur not in coincfg and maxtolent != 0 and restrictLent == True):
 		log.updateStatusValue(activeCur, "maxToLend", maxtolent)
                 if(lendingBalance > (activeCurTestBalance - maxtolent)):
 			activeBal = (lendingBalance - (activeCurTestBalance - maxtolent))
-	if(activeCur not in coincfg and maxtolent == 0 and maxpercenttolent != 0):
+	if(activeCur not in coincfg and maxtolent == 0 and maxpercenttolent != 0 and restrictLent == True):
 		log.updateStatusValue(activeCur, "maxToLend", (maxpercenttolent * activeCurTestBalance))
                 if(lendingBalance > (activeCurTestBalance - (maxpercenttolent * activeCurTestBalance))):
 			activeBal = (lendingBalance - (activeCurTestBalance - (maxpercenttolent * activeCurTestBalance)))

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,9 +329,10 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	activeBal = Decimal(0)
+	logdata = str("")
 	if (activeCur in coincfg):
 		if (coincfg[activeCur]['maxtolentrate'] == 0 and lowrate > 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
-			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
+			logdata = ("The Lower Rate found on "+activeCur+" is "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"%. ")
 			restrictLent = True
 		if  coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:
 			log.updateStatusValue(activeCur, "maxToLend", coincfg[activeCur]['maxtolent'])
@@ -347,7 +348,7 @@ def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 		
 	if (activeCur not in coincfg):
 		if(maxtolentrate == 0 and lowrate > 0 or lowrate <= maxtolentrate and lowrate > 0):
-                	log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
+                	logdata = ("The Lower Rate found on "+activeCur+" is "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"%. ")
                 	restrictLent = True
 		if(maxtolent != 0 and restrictLent == True):
 			log.updateStatusValue(activeCur, "maxToLend", maxtolent)
@@ -365,6 +366,8 @@ def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 		activeBal = lendingBalance
 	if((lendingBalance - activeBal) < 0.001):
 		activeBal = lendingBalance
+	if(activeBal < lendingBalance):
+		log.log(logdata+" Lending "+str("%.8f" % Decimal(activeBal))+" of "+str("%.8f" % Decimal(lendingBalance))+" Available")
 	return activeBal
 
 def cancelAndLoanAll():

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,10 +329,10 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
-		log.log("Low Rate "+str("%.8f" % Decimal(lowrate)*100)+" vs conditional rate "+str("%.8f" % Decimal(coincfg[activeCur]['maxtolentrate'])*100))
+		log.log("Low Rate "+str("%.8f" % (Decimal(lowrate)*100))+" vs conditional rate "+str("%.8f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100)))
 		restrictLent = True
 	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
-		log.log("Low Rate "+str("%.8f" % Decimal(lowrate)*100)+" vs conditional rate "+str("%.8f" % Decimal(maxtolentrate)*100))
+		log.log("Low Rate "+str("%.8f" % (Decimal(lowrate)*100))+" vs conditional rate "+str("%.8f" % (Decimal(maxtolentrate)*100)))
 		restrictLent = True
 	activeBal = Decimal(0)
 	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -414,8 +414,9 @@ def cancelAndLoanAll():
 		loans = bot.returnLoanOrders(activeCur, loanOrdersRequestLimit[activeCur] )
 		loansLength = len(loans['offers'])
 		
-		for offer in loans['offers']:
-			print(offer['rate'])
+		#for offer in loans['offers']:
+		#	print(offer['rate'])
+		print(loans['offers'][0]['rate'])
 		
 		activeBal = amountToLent(activeCurTestBalance,activeCur,Decimal(lendingBalances[activeCur]))
 		

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,11 +329,11 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
-		if lowrate > 0
+		if(lowrate > 0)
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
 	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
-		and lowrate > 0
+		if(lowrate > 0)
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -382,8 +382,13 @@ def cancelAndLoanAll():
                 if activeCur in totalLended:
                 	activeCurTestBalance += Decimal(totalLended[activeCur])
 		activeBal = amountToLent(activeCurTestBalance,activeCur,Decimal(lendingBalances[activeCur]))
+		
+		#log total coin
+		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur])))
+
 		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
 			usableCurrencies = 1
+			continue
 		
 		#min daily rate can be changed per currency
 		curMinDailyRate = minDailyRate
@@ -411,8 +416,6 @@ def cancelAndLoanAll():
 		activePlusLended = Decimal(activeBal)
 		if activeCur in totalLended:
 			activePlusLended += Decimal(totalLended[activeCur])
-		#log total coin
-		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur])))
 		if loansLength == 0:
 			createLoanOffer(activeCur,Decimal(activeBal)-lent,maxDailyRate)
 		for offer in loans['offers']:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -393,7 +393,7 @@ def cancelAndLoanAll():
 			log.log('Using custom mindailyrate ' + str(coincfg[activeCur]['minrate']*100) + '% for ' + activeCur)
 
 		#log total coin
-		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur])))
+		log.updateStatusValue(activeCur, "totalCoins", (Decimal(activeCurTestBalance))
 
 		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
 			usableCurrencies = 1

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -328,11 +328,11 @@ defaultLoanOrdersRequestLimit = 200
 
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
-	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
-		log.log("Low Rate "+str(lowrate)+" vs conditional rate "+str(coincfg[activeCur]['maxtolentrate']))
+	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
+		log.log("Low Rate "+str("%.8f" % Decimal(lowrate)*100)+" vs conditional rate "+str("%.8f" % Decimal(coincfg[activeCur]['maxtolentrate'])*100))
 		restrictLent = True
-	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
-		log.log("Low Rate "+str(lowrate)+" vs conditional rate "+str(maxtolentrate))
+	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
+		log.log("Low Rate "+str("%.8f" % Decimal(lowrate)*100)+" vs conditional rate "+str("%.8f" % Decimal(maxtolentrate)*100))
 		restrictLent = True
 	activeBal = Decimal(0)
 	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -397,6 +397,7 @@ def cancelAndLoanAll():
 
 		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
 			usableCurrencies = 1
+		else:
 			continue
 		
 		# make sure we have a request limit for this currency

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -58,11 +58,15 @@ autorenew = 0
 #Max percent to lent. if set to 0 or commented the bot will lent the 100%.
 #maxpercenttolent = 0
 
-#syntax: ["COIN:mindailyrate:maxactiveamount:maxtolent:maxpercenttolent",...]
+#Max to lent conditional rate. if set to more than 0 the maxtolent or maxpercenttolent will be used when then rate is less or equal to the maxtolentrate. if set to 0 or commented the bot will use the maxtolent or maxpercenttolent all the time.
+#maxtolentrate = 0
+
+#syntax: ["COIN:mindailyrate:maxactiveamount:maxtolent:maxpercenttolent:maxtolentrate",...]
 #if maxactive amount is 0 - stop lending this coin. in the future you'll be able to limit amount to be lent.
 #if maxtolent is 0 - check for maxpercenttolent.
 #if maxpercenttolent is 0 - 100% is going to be lent.
-#coinconfig = ["BTC:0.18:1:0:0","CLAM:0.6:1:0:0"]
+if #maxtolentrate is set to more than 0 the maxtolent or maxpercenttolent will be used when then rate is less or equal to the maxtolentrate. if set to 0 the bot will use the maxtolent or maxpercenttolent all the time.
+#coinconfig = ["BTC:0.18:1:0:0:0","CLAM:0.6:1:0:0:0"]
 
 #this option creates a json log file instead of console output which includes the most recent status
 #uncomment both jsonfile and jsonlogsize to enable

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -339,7 +339,7 @@ def amountToLent(activeCurTestBalance,activeCur,lendingBalance):
 	if(activeCur not in coincfg and maxtolent == 0 and maxpercenttolent == 0):
 		log.updateStatusValue(activeCur, "maxToLend", activeCurTestBalance)
 		activeBal = lendingBalance
-return activeBal
+	return activeBal
 
 def cancelAndLoanAll():
 	loanOffers = bot.returnOpenLoanOffers()

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -328,10 +328,10 @@ defaultLoanOrdersRequestLimit = 200
 
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
-	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 and lowrate <= coincfg[activeCur]['maxtolentrate']):
+	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
 		log.log("Low Rate "+str(lowrate)+" vs conditional rate "+str(coincfg[activeCur]['maxtolentrate']))
 		restrictLent = True
-	if(activeCur not in coincfg and maxtolentrate == 0 and lowrate <= maxtolentrate):
+	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
 		log.log("Low Rate "+str(lowrate)+" vs conditional rate "+str(maxtolentrate))
 		restrictLent = True
 	activeBal = Decimal(0)
@@ -355,6 +355,9 @@ def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
                 if(lendingBalance > (activeCurTestBalance - (maxpercenttolent * activeCurTestBalance))):
 			activeBal = (lendingBalance - (activeCurTestBalance - (maxpercenttolent * activeCurTestBalance)))
 	if(activeCur not in coincfg and maxtolent == 0 and maxpercenttolent == 0):
+		log.updateStatusValue(activeCur, "maxToLend", activeCurTestBalance)
+		activeBal = lendingBalance
+	if restrictLent == False:
 		log.updateStatusValue(activeCur, "maxToLend", activeCurTestBalance)
 		activeBal = lendingBalance
 	return activeBal

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -393,7 +393,7 @@ def cancelAndLoanAll():
 			log.log('Using custom mindailyrate ' + str(coincfg[activeCur]['minrate']*100) + '% for ' + activeCur)
 
 		#log total coin
-		log.updateStatusValue(activeCur, "totalCoins", (Decimal(activeCurTestBalance))
+		log.updateStatusValue(activeCur, "totalCoins", (Decimal(activeCurTestBalance)))
 
 		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
 			usableCurrencies = 1

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -328,10 +328,10 @@ defaultLoanOrdersRequestLimit = 200
 
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
-	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
+	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 and lowrate > 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
 		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
-	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
+	if(activeCur not in coincfg and maxtolentrate == 0 and lowrate > 0 or lowrate <= maxtolentrate and lowrate > 0):
 		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,10 +329,10 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
-			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
+		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
 	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
-			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
+		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)
 	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -328,11 +328,13 @@ defaultLoanOrdersRequestLimit = 200
 
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
-	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
-		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
+	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
+		if lowrate > 0
+			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
-	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
-		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
+	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
+		and lowrate > 0
+			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)
 	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,10 +329,10 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate'] and lowrate > 0):
-		log.log("Low Rate "+str("%.8f" % (Decimal(lowrate)*100))+" vs conditional rate "+str("%.8f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100)))
+		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
 	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate and lowrate > 0):
-		log.log("Low Rate "+str("%.8f" % (Decimal(lowrate)*100))+" vs conditional rate "+str("%.8f" % (Decimal(maxtolentrate)*100)))
+		log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)
 	if activeCur in coincfg and coincfg[activeCur]['maxtolent'] != 0 and restrictLent == True:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -329,11 +329,11 @@ defaultLoanOrdersRequestLimit = 200
 def amountToLent(activeCurTestBalance,activeCur,lendingBalance,lowrate):
 	restrictLent = False
 	if(activeCur in coincfg and coincfg[activeCur]['maxtolentrate'] == 0 or lowrate <= coincfg[activeCur]['maxtolentrate']):
-		if(lowrate > 0)
+		if(Decimal(lowrate) > 0)
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(coincfg[activeCur]['maxtolentrate'])*100))+"% "+activeCur)
 		restrictLent = True
 	if(activeCur not in coincfg and maxtolentrate == 0 or lowrate <= maxtolentrate):
-		if(lowrate > 0)
+		if(Decimal(lowrate) > 0)
 			log.log("Low Rate "+str("%.4f" % (Decimal(lowrate)*100))+"% vs conditional rate "+str("%.4f" % (Decimal(maxtolentrate)*100))+"% "+activeCur)
 		restrictLent = True
 	activeBal = Decimal(0)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -161,7 +161,7 @@ else:
 if args.maxpercenttolent:
 	maxpercenttolent = Decimal(args.maxpercenttolent)/100
 else:
-maxpercenttolent = 0
+	maxpercenttolent = 0
 #End handling args.
 
 #Check if we need a config file at all (If all settings are passed by args, we won't)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -383,13 +383,6 @@ def cancelAndLoanAll():
                 	activeCurTestBalance += Decimal(totalLended[activeCur])
 		activeBal = amountToLent(activeCurTestBalance,activeCur,Decimal(lendingBalances[activeCur]))
 		
-		#log total coin
-		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur])))
-
-		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
-			usableCurrencies = 1
-			continue
-		
 		#min daily rate can be changed per currency
 		curMinDailyRate = minDailyRate
 		if activeCur in coincfg:
@@ -399,6 +392,13 @@ def cancelAndLoanAll():
 			curMinDailyRate = coincfg[activeCur]['minrate']
 			log.log('Using custom mindailyrate ' + str(coincfg[activeCur]['minrate']*100) + '% for ' + activeCur)
 
+		#log total coin
+		log.updateStatusValue(activeCur, "totalCoins", (Decimal(lendingBalances[activeCur])+Decimal(totalLended[activeCur])))
+
+		if float(activeBal) > minLoanSize: #Check if any currencies have enough to lend, if so, make sure sleeptimer is set to active.
+			usableCurrencies = 1
+			continue
+		
 		# make sure we have a request limit for this currency
 		if(activeCur not in loanOrdersRequestLimit):
 			loanOrdersRequestLimit[activeCur] = defaultLoanOrdersRequestLimit

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -405,8 +405,7 @@ def startWebServer():
 
 	try:
 		PORT = 8000
-		HOST = '0.0.0.0'
-		#'127.0.0.1'
+		HOST = '127.0.0.1'
 
 		class QuietHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 			# quiet server logs

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -292,14 +292,8 @@ def cancelAndLoanAll():
 		for offer in loanOffers[cur]:
 			onOrderBalances[cur] = onOrderBalances.get(cur, 0) + Decimal(offer['amount'])
 			if dryRun == False:
-				try:
-					msg = bot.cancelLoanOffer(cur,offer['id'])
-					log.cancelOrders(cur, msg)
-				except Exception as e:
-					log.log("Error canceling loan offer: " + str(e))
-
-				#msg = bot.cancelLoanOffer(cur,offer['id'])
-				#log.cancelOrders(cur, msg)
+				msg = bot.cancelLoanOffer(cur,offer['id'])
+				log.cancelOrders(cur, msg)
 
 	lendingBalances = bot.returnAvailableAccountBalances("lending")['lending']
 	if dryRun == True: #just fake some numbers, if dryrun (testing)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -140,7 +140,7 @@ else:
 #End handling args.
 
 #Check if we need a config file at all (If all settings are passed by args, we won't)
-if args.apikey and args.apisecret and args.sleeptimeactive and args.sleeptimeinactive and args.mindailyrate and args.maxdailyrate and args.spreadlend and args.gapbottom and args.gaptop and args.sixtydaythreshold and args.nobtc:
+if args.apikey and args.apisecret and args.sleeptimeactive and args.sleeptimeinactive and args.mindailyrate and args.maxdailyrate and args.spreadlend and args.gapbottom and args.gaptop and args.sixtydaythreshold:
 	#If all that was true, we don't need a config file...
 	config_needed = False
 	print "Settings met from arguments."

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -274,10 +274,6 @@ def cancelAndLoanAll():
 	loanOffers = bot.returnOpenLoanOffers()
 	if type(loanOffers) is list: #silly api wrapper, empty dict returns a list, which brakes the code later.
 		loanOffers = {}
-	if loanOffers.get('error'):
-		print loanOffers.get('error')
-		print 'You might want to edit config file (default.cfg) and put correct apisecret and key values'
-		exit(1)
 
 	onOrderBalances = {}
 	for cur in loanOffers:
@@ -462,12 +458,27 @@ try:
 			cancelAndLoanAll()
 			log.refreshStatus(stringifyTotalLended())
 			log.persistStatus()
+			sys.stdout.flush()
 			time.sleep(sleepTime)
 		except Exception as e:
 			log.log("ERROR: " + str(e))
-			traceback.print_exc()
 			log.persistStatus()
-			time.sleep(sleepTime)
+			print timestamp();
+			print traceback.format_exc()
+			if('Invalid API key' in str(e)):
+				print "!!! Troubleshooting !!!"
+				print "Are your API keys correct? No quotation. Just plain keys."
+				exit(1);
+			if('Nonce must be greater' in str(e)):
+				print "!!! Troubleshooting !!!"
+				print "Are you reusing the API key in multiple applications? use a unique key for every application."
+				exit(1);
+			if('Permission denied' in str(e)):
+				print "!!! Troubleshooting !!!"
+				print "Are you using IP filter on the key? Maybe your IP changed?"
+				exit(1);
+			sys.stdout.flush()
+			time.sleep(sleepTime)			
 			pass
 except KeyboardInterrupt:
 	if autoRenew == 1:

--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -42,6 +42,7 @@ function updateRawValues(rawData){
         var averageLendingRate = parseFloat(rawData[currency]['averageLendingRate']);
         var lentSum = parseFloat(rawData[currency]['lentSum']);
         var totalCoins = parseFloat(rawData[currency]['totalCoins']);
+	var maxToLend = parseFloat(rawData[currency]['maxToLend']);
         var highestBidBTC = parseFloat(rawData[currency]['highestBid']);
         var couple = rawData[currency]['couple'];
 
@@ -82,12 +83,13 @@ function updateRawValues(rawData){
             var yearlyRate = effectiveRate * 365; // no reinvestment
             var yearlyRateReinv = (Math.pow(effectiveRate / 100 + 1, 365) - 1) * 100; // with daily reinvestment
             var lentPerc = lentSum / totalCoins * 100;
+	    var lentPercLendable = lentSum / maxToLend * 100;
             var avgRateText = '&nbsp;<span style="white-space:nowrap;" title="Average loan rate, simple average calculation of active loans rates.">Avg. (i)</span>';
             var effRateText =  '&nbsp;<span style="white-space:nowrap;" title="Effective loan rate, considering lent precentage and poloniex 15% fee.">Eff. (i)</span>';
             var compoundRateText =  '&nbsp;<span style="white-space:nowrap;" title="Compound yearly rate, the result of reinvesting the interest.">Comp. (i)</span>';
 
             var rowValues = ["<b>" + currency + "</b>",
-                'Lent ' + printFloat(lentSum, 4) +' of ' + printFloat(totalCoins, 4) + ' (' + printFloat(lentPerc, 2) + '%)',
+                'Lent ' + printFloat(lentSum, 4) +' of ' + printFloat(totalCoins, 4) + ' (' + printFloat(lentPerc, 2) + '%)'+' <b>Total</b><br/>'+'Lent ' + printFloat(lentSum, 4) +' of ' + printFloat(maxToLend, 4) + ' (' + printFloat(lentPercLendable, 2) + '%)  <b>Lendable</b>' ,
                 "<div class='inlinediv' >" + printFloat(averageLendingRate, 5) + '% Day' + avgRateText + '<br/>'
                     + printFloat(effectiveRate, 5) + '% Day' + effRateText + '<br/></div>' 
                     + "<div class='inlinediv' >" + printFloat(yearlyRate, 2) + '% Year<br/>'

--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -189,7 +189,7 @@ function Timespan(name, multiplier) {
                 currencyClass = 'hidden-xs';
             }
 	    if(currency == "USDT") {
-            	return printFloat((earnings*BTC_Val), 4) + " <span class=" + currencyClass + ">USD("+printFloat(BTC_Val, 2)+")</span> / " + name + "<br/>";
+            	return printFloat((earnings*BTC_Val), 8) + " <span class=" + currencyClass + ">USD(@ "+printFloat(BTC_Val, 2)+")</span> / " + name + "<br/>";
 	    } else {
 		return printFloat(earnings, 8) + " <span class=" + currencyClass + ">" + currency + "</span> / "+  name + "<br/>";
 	    }

--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -5,6 +5,8 @@ var Day = new Timespan("Day",1);
 var Week = new Timespan("Week",7);
 var Month = new Timespan("Month",30);
 var timespans = [Month, Week, Day, Hour];
+var BTC_Val;
+var isBTC = true;
 
 function updateJson(data) {
     $('#status').text(data.last_status);
@@ -56,10 +58,14 @@ function updateRawValues(rawData){
                 earnings += timespan.formatEarnings(currency, timespanEarning);
                 if(currency == 'BTC') {
                     totalBTCEarnings[timespan.name] += timespanEarning;
+			if(!isNaN(highestBidBTC)) {
+				BTC_Val = highestBidBTC;
+				isBTC = false;
+			}
                 }
 
                 // calculate BTC earnings
-                if(!isNaN(highestBidBTC)) {
+                if(!isNaN(highestBidBTC) && !(currency == 'BTC')) {
                     timespanEarningBTC = timespan.calcEarnings(lentSum * highestBidBTC, rate);
                     earningsBTC += timespan.formatEarnings("BTC", timespanEarningBTC);
                     totalBTCEarnings[timespan.name] += timespanEarningBTC;
@@ -118,7 +124,11 @@ function updateRawValues(rawData){
     if(currencies.length > 1) {
         earnings = '';
         timespans.forEach(function(timespan) {
-            earnings += timespan.formatEarnings( 'BTC', totalBTCEarnings[timespan.name]);
+		if(isBTC == false) {
+            		earnings += timespan.formatEarnings( 'USDT', totalBTCEarnings[timespan.name]);
+		} else {
+			earnings += timespan.formatEarnings( 'BTC', totalBTCEarnings[timespan.name]);
+		}
         });
         var row = thead.insertRow(0);
         var cell = row.appendChild(document.createElement("th"));
@@ -175,10 +185,14 @@ function Timespan(name, multiplier) {
             return printFloat(earnings * 100000000, 0) + " Satoshi / " + name + "<br/>";
         } else {
             var currencyClass = '';
-            if(currency != "BTC") {
+            if(currency != "BTC" && currency != "USDT") {
                 currencyClass = 'hidden-xs';
             }
-            return printFloat(earnings, 8) + " <span class=" + currencyClass + ">" + currency + "</span> / " + name + "<br/>";
+	    if(currency == "USDT") {
+            	return printFloat((earnings*BTC_Val), 4) + " <span class=" + currencyClass + ">USD("+printFloat(BTC_Val, 2)+")</span> / " + name + "<br/>";
+	    } else {
+		return printFloat(earnings, 8) + " <span class=" + currencyClass + ">" + currency + "</span> / "+  name + "<br/>";
+	    }
         }
     };
 }

--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -5,8 +5,8 @@ var Day = new Timespan("Day",1);
 var Week = new Timespan("Week",7);
 var Month = new Timespan("Month",30);
 var timespans = [Month, Week, Day, Hour];
-var BTC_Val;
-var isBTC = true;
+var Coin_Val = 1.00000000;
+var Coin = "BTC";
 
 function updateJson(data) {
     $('#status').text(data.last_status);
@@ -19,7 +19,16 @@ function updateJson(data) {
         table.append($('<tr/>').append($('<td colspan="2" />').text(data.log[i])));
     }
 
+    updateOutputCurrency(data.outputCurrency);
     updateRawValues(data.raw_data);
+}
+
+function updateOutputCurrency(outputCurrency){
+	var OutCurr = Object.keys(outputCurrency);
+	Coin = outputCurrency['currency'];
+	if(Coin != "BTC") {
+		Coin_Val = parseFloat(outputCurrency['highestBid']);
+	}	
 }
 
 function updateRawValues(rawData){
@@ -58,10 +67,6 @@ function updateRawValues(rawData){
                 earnings += timespan.formatEarnings(currency, timespanEarning);
                 if(currency == 'BTC') {
                     totalBTCEarnings[timespan.name] += timespanEarning;
-			if(!isNaN(highestBidBTC)) {
-				BTC_Val = highestBidBTC;
-				isBTC = false;
-			}
                 }
 
                 // calculate BTC earnings
@@ -124,10 +129,14 @@ function updateRawValues(rawData){
     if(currencies.length > 1) {
         earnings = '';
         timespans.forEach(function(timespan) {
-		if(isBTC == false) {
-            		earnings += timespan.formatEarnings( 'USDT', totalBTCEarnings[timespan.name]);
-		} else {
-			earnings += timespan.formatEarnings( 'BTC', totalBTCEarnings[timespan.name]);
+		if(Coin == "BTC") {
+            		earnings += timespan.formatEarnings( Coin, totalBTCEarnings[timespan.name]);
+		}
+		if(Coin == "USDT") {
+			earnings += timespan.formatEarnings( Coin, totalBTCEarnings[timespan.name]*Coin_Val);
+		}
+		if(Coin != "BTC" && Coin != "USDT") {
+			earnings += timespan.formatEarnings( Coin, totalBTCEarnings[timespan.name]/Coin_Val);
 		}
         });
         var row = thead.insertRow(0);
@@ -188,11 +197,8 @@ function Timespan(name, multiplier) {
             if(currency != "BTC" && currency != "USDT") {
                 currencyClass = 'hidden-xs';
             }
-	    if(currency == "USDT") {
-            	return printFloat((earnings*BTC_Val), 8) + " <span class=" + currencyClass + ">USD(@ "+printFloat(BTC_Val, 2)+")</span> / " + name + "<br/>";
-	    } else {
-		return printFloat(earnings, 8) + " <span class=" + currencyClass + ">" + currency + "</span> / "+  name + "<br/>";
-	    }
+	return printFloat(earnings, 8) + " <span class=" + currencyClass + ">" + currency + "</span> / "+  name + "<br/>";
+	    
         }
     };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Why is this change required? What problem does it solve? -->
I made the feature, to choose the amount or percent you want to lent. but it includes the changes on the #112

When I create this feature discover or create a bug that when you have balance not lent on Lending and is less than minLoanSize the bot make more than 6 api calls per second. I change that. Now if the activeBal is less than minLoanSize it update the totalCoins and skip to the next coin.


in the config is like that
```
#Max amount to lent. if set to 0 or commented the bot will check for maxpercenttolent.
#maxtolent = 0

#Max percent to lent. if set to 0 or commented the bot will lent the 100%.
#maxpercenttolent = 0

#Max to lent conditional rate. if set to more than 0 the maxtolent or maxpercenttolent will be used when then rate is less or equal to the maxtolentrate. if set to 0 or commented the bot will use the maxtolent or maxpercenttolent all the time.
#maxtolentrate = 0

#syntax: ["COIN:mindailyrate:maxactiveamount:maxtolent:maxpercenttolent:maxtolentrate",...]
#if maxactive amount is 0 - stop lending this coin. in the future you'll be able to limit amount to be lent.
#if maxtolent is 0 - check for maxpercenttolent.
#if maxpercenttolent is 0 - 100% is going to be lent.
if #maxtolentrate if set to more than 0 the maxtolent or maxpercenttolent will be used when then rate is less or equal to the maxtolentrate. if set to 0 the bot will use the maxtolent or maxpercenttolent all the time.
#coinconfig = ["BTC:0.18:1:0:0:0","CLAM:0.6:1:0:0:0"]
```

```
parser.add_argument("-maxlent", "--maxtolent", help="Max amount to lent. if set to 0 the bot will check for maxpercenttolent.")
parser.add_argument("-maxplent", "--maxpercenttolent", help="Max percent to lent. if set to 0 the bot will lent the 100%.")
parser.add_argument("-maxlentr", "--maxtolentrate", help="Max to lent rate. if set to more than 0 the maxtolent or maxpercenttolent will be used when then rate is less or equal to the maxtolentrate. if set to 0 the bot will use the maxtolent or maxpercenttolent all the time. The default is 0")

```

Screenshot
![screenshot - 100616 - 00 18 59](https://cloud.githubusercontent.com/assets/18429660/19140380/9429ec00-8b5a-11e6-833b-ce72f67dc0a4.png)

if you set the maxtolent or maxpercenttolent after the bot has lent all the balance or if you has set the maxtolentrate and the price drop after the bot has lent all the balance, you are going to see something like this.
![screenshot - 100716 - 10 36 03](https://cloud.githubusercontent.com/assets/18429660/19193988/2291777c-8c7a-11e6-9a58-df80faa562a8.png)


on the log
![screenshot - 100616 - 17 03 52](https://cloud.githubusercontent.com/assets/18429660/19170693/729aa344-8be7-11e6-9962-bc642a7d562a.png)


I place the both values in the web because I think that maybe its useful to know the values in the case that you want to transfer this amounts to another place.

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->

- I tested the percent and fixed for 24 hours. 

- I tested the fix for the error of the  6 api calls.

- I tested the conditional rate option.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points -->
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/) **
- [x] **My code adheres to the code style of this project**
- [x] **If my change requires a change to the config, I have updated the config file and command line arguments accordingly.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
