### PR TITLE
Add End Date

### DIFF
--- a/Logger.py
+++ b/Logger.py
@@ -46,8 +46,8 @@ class JsonOutput(object):
         self.clearStatusValues()
         self.jsonOutputLog = RingBuffer(logLimit)
 
-    def status(self, status, time):
-        self.jsonOutput["last_update"] = time
+    def status(self, status, time, days_remaining):
+        self.jsonOutput["last_update"] = time + " - Days Remaining: " + days_remaining
         self.jsonOutput["last_status"] = status
 
     def printline(self, line):
@@ -77,6 +77,7 @@ class JsonOutput(object):
 class Logger(object):
     def __init__(self, json_file='', json_log_size=-1):
         self._lended = ''
+        self._daysRemaining = 'Not Set'
         if json_file != '' and json_log_size != -1:
             self.console = JsonOutput(json_file, json_log_size)
         else:
@@ -102,10 +103,12 @@ class Logger(object):
         self.console.printline(line)
         self.refreshStatus()
 
-    def refreshStatus(self, lended=''):
+    def refreshStatus(self, lended='', days_remaining=''):
         if lended != '':
             self._lended = lended
-        self.console.status(self._lended, self.timestamp())
+        if days_remaining != '':
+            self._daysRemaining = days_remaining
+        self.console.status(self._lended, self.timestamp(), self._daysRemaining)
 
     def updateStatusValue(self, coin, key, value):
         if hasattr(self.console, 'statusValue'):

--- a/Logger.py
+++ b/Logger.py
@@ -46,8 +46,8 @@ class JsonOutput(object):
         self.clearStatusValues()
         self.jsonOutputLog = RingBuffer(logLimit)
 
-    def status(self, status, time, days_remaining):
-        self.jsonOutput["last_update"] = time + " - Days Remaining: " + days_remaining
+    def status(self, status, time, days_remaining_msg):
+        self.jsonOutput["last_update"] = time + days_remaining_msg
         self.jsonOutput["last_status"] = status
 
     def printline(self, line):

--- a/Logger.py
+++ b/Logger.py
@@ -77,7 +77,7 @@ class JsonOutput(object):
 class Logger(object):
     def __init__(self, json_file='', json_log_size=-1):
         self._lended = ''
-        self._daysRemaining = 'Not Set'
+        self._daysRemaining = ''
         if json_file != '' and json_log_size != -1:
             self.console = JsonOutput(json_file, json_log_size)
         else:

--- a/default.cfg.example
+++ b/default.cfg.example
@@ -44,6 +44,11 @@ minloansize = 0.001
 #AutoRenew - if set to 1 the bot will set the AutoRenew flag for the loans when you stop it (Ctrl+C) and clear the AutoRenew flag when on started
 autorenew = 0
 
+#End date for lending, bot will try to make sure all your loans are done by this date so you can withdraw or do whatever you need.
+#Uncomment to enable.
+#Format: YEAR,MONTH,DAY
+#endDate = 2016,12,25
+
 #Max amount to lent. if set to 0 or commented the bot will check for maxpercenttolent.(0+)
 #maxtolent = 0
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -128,6 +128,12 @@ Very few situations require you to change these settings.
 
 ``autorenew`` If 0, does nothing. If 1, will enable autorenew on loans once the bot closes with CTRL-C.
 
+``endDate`` Bot will try to make sure all your loans are done by this date so you can withdraw or do whatever you need.
+
+- Default value: Disabled
+- Uncomment to enable.
+- Format: ``YEAR,MONTH,DAY``
+
 2.8 Max to be lent
 ------------------
 

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -289,7 +289,8 @@ def create_loan_offer(currency, amt, rate):
                 days = days_remaining
             if days < '2':
                 print "The day of ending is upon us. (endDate reached)\nNow exiting..."
-                sys.exit(0)
+                log.log("endDate reached. Bot can no longer lend. Exiting.")
+                exit(0)
         if not dry_run:
             msg = bot.createLoanOffer(currency, amt, days, 0, rate)
             log.offer(amt, currency, rate, days, msg)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -374,12 +374,14 @@ def get_on_order_balances():
 
 
 def get_max_duration():
+    if not config.get('BOT', 'endDate'):
+        return "Not Set"
     try:
         now_time = datetime.date.today()
         config_date = map(int, config.get('BOT', 'endDate').split(','))
         end_time = datetime.date(*config_date)  # format YEAR,MONTH,DAY all ints, also used splat operator
-        diff_days = end_time - now_time
-        return str(diff_days.days)
+        diff_days = (end_time - now_time).days
+        return str(diff_days)
     except Exception as E:
         print "ERROR: There is something wrong with your endDate option. Error: " + str(E)
 
@@ -642,7 +644,7 @@ try:
             transfer_balances()
             cancel_all()
             loan_all()
-            log.refreshStatus(stringify_total_lended())
+            log.refreshStatus(stringify_total_lended(), get_max_duration())
             log.persistStatus()
             sys.stdout.flush()
             time.sleep(sleep_time)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -285,12 +285,12 @@ def create_loan_offer(currency, amt, rate):
             days = '2'
         if config.has_option('BOT', 'endDate'):
             days_remaining = get_max_duration("order")
-            if days > days_remaining:
-                days = days_remaining
-            if days < '2':
+            if days_remaining <= "2":
                 print "endDate reached. Bot can no longer lend.\nExiting..."
                 log.log("endDate reached. Bot can no longer lend. Exiting.")
                 exit(0)
+            if days > days_remaining:
+                days = days_remaining
         if not dry_run:
             msg = bot.createLoanOffer(currency, amt, days, 0, rate)
             log.offer(amt, currency, rate, days, msg)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -275,7 +275,6 @@ def stringify_total_lended():
 
 def create_loan_offer(currency, amt, rate):
     days = '2'
-    days_remaining = get_max_duration()
     # if (min_daily_rate - 0.000001) < rate and Decimal(amt) > min_loan_size:
     if float(amt) > min_loan_size:
         rate = float(rate) - 0.000001  # lend offer just bellow the competing one
@@ -285,6 +284,7 @@ def create_loan_offer(currency, amt, rate):
         if xday_threshold == 0:
             days = '2'
         if config.has_option('BOT', 'endDate'):
+            days_remaining = get_max_duration()
             if days > days_remaining:
                 days = days_remaining
             if days < '2':

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -364,6 +364,17 @@ def get_on_order_balances():
     return on_order_balances
 
 
+def get_max_duration():
+    try:
+        now_time = datetime.date.today()
+        config_date = map(int, config.get('BOT', 'endDate').split(','))
+        end_time = datetime.date(*config_date)  # format YEAR,MONTH,DAY all ints, also used splat operator
+        diff_days = end_time - now_time
+        return diff_days.days
+    except Exception as E:
+        print "ERROR: There is something wrong with your endDate option. Error: " + str(E)
+
+
 def cancel_all():
     loan_offers = get_open_offers()
     for CUR in loan_offers:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -288,6 +288,7 @@ def create_loan_offer(currency, amt, rate):
             if int(days_remaining) <= 2:
                 print "endDate reached. Bot can no longer lend.\nExiting..."
                 log.log("endDate reached. Bot can no longer lend. Exiting.")
+                log.refreshStatus(stringify_total_lended(), get_max_duration("status"))
                 exit(0)
             if days > days_remaining:
                 days = str(days_remaining)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -288,7 +288,7 @@ def create_loan_offer(currency, amt, rate):
             if days > days_remaining:
                 days = days_remaining
             if days < '2':
-                print "The day of ending is upon us. (endDate reached)\nNow exiting..."
+                print "endDate reached. Bot can no longer lend.\nExiting..."
                 log.log("endDate reached. Bot can no longer lend. Exiting.")
                 exit(0)
         if not dry_run:

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -289,6 +289,7 @@ def create_loan_offer(currency, amt, rate):
                 print "endDate reached. Bot can no longer lend.\nExiting..."
                 log.log("endDate reached. Bot can no longer lend. Exiting.")
                 log.refreshStatus(stringify_total_lended(), get_max_duration("status"))
+                log.persistStatus()
                 exit(0)
             if days > days_remaining:
                 days = str(days_remaining)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -275,6 +275,7 @@ def stringify_total_lended():
 
 def create_loan_offer(currency, amt, rate):
     days = '2'
+    days_remaining = get_max_duration()
     # if (min_daily_rate - 0.000001) < rate and Decimal(amt) > min_loan_size:
     if float(amt) > min_loan_size:
         rate = float(rate) - 0.000001  # lend offer just bellow the competing one
@@ -283,9 +284,16 @@ def create_loan_offer(currency, amt, rate):
             days = xdays
         if xday_threshold == 0:
             days = '2'
+        if config.has_option('BOT', 'endDate'):
+            if days > days_remaining:
+                days = days_remaining
+            if days < '2':
+                print "The day of ending is upon us. (endDate reached)\nNow exiting..."
+                sys.exit(0)
         if not dry_run:
             msg = bot.createLoanOffer(currency, amt, days, 0, rate)
             log.offer(amt, currency, rate, days, msg)
+
 
 # limit of orders to request
 loanOrdersRequestLimit = {}
@@ -370,7 +378,7 @@ def get_max_duration():
         config_date = map(int, config.get('BOT', 'endDate').split(','))
         end_time = datetime.date(*config_date)  # format YEAR,MONTH,DAY all ints, also used splat operator
         diff_days = end_time - now_time
-        return diff_days.days
+        return str(diff_days.days)
     except Exception as E:
         print "ERROR: There is something wrong with your endDate option. Error: " + str(E)
 

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -359,7 +359,7 @@ def amount_to_lent(active_cur_test_balance, active_cur, lending_balance, low_rat
 
 def get_open_offers():
     loan_offers = bot.returnOpenLoanOffers()
-    if type(loan_offers) is list:  # silly api wrapper, empty dict returns a list, which breaks the code later.
+    if isinstance(loan_offers, list):  # silly api wrapper, empty dict returns a list, which breaks the code later.
         loan_offers = {}
     return loan_offers
 
@@ -407,7 +407,7 @@ def cancel_all():
 def loan_all():
     lending_balances = bot.returnAvailableAccountBalances("lending")['lending']
     if dry_run:  # just fake some numbers, if dryrun (testing)
-        if type(lending_balances) is list:  # silly api wrapper, empty dict returns a list, which breaks the code later.
+        if isinstance(lending_balances, list):  # silly api wrapper, empty dict returns a list, which breaks the code later.
             lending_balances = {}
         lending_balances.update(get_on_order_balances())
 

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -284,7 +284,7 @@ def create_loan_offer(currency, amt, rate):
         if xday_threshold == 0:
             days = '2'
         if config.has_option('BOT', 'endDate'):
-            days_remaining = get_max_duration()
+            days_remaining = get_max_duration("order")
             if days > days_remaining:
                 days = days_remaining
             if days < '2':
@@ -373,17 +373,20 @@ def get_on_order_balances():
     return on_order_balances
 
 
-def get_max_duration():
+def get_max_duration(context):
     if not config.get('BOT', 'endDate'):
-        return "Not Set"
+        return ""
     try:
         now_time = datetime.date.today()
         config_date = map(int, config.get('BOT', 'endDate').split(','))
         end_time = datetime.date(*config_date)  # format YEAR,MONTH,DAY all ints, also used splat operator
         diff_days = (end_time - now_time).days
-        return str(diff_days)
     except Exception as E:
         print "ERROR: There is something wrong with your endDate option. Error: " + str(E)
+    if context == "order":
+        return diff_days
+    if context == "status":
+        return " - Days Remaining: " + diff_days
 
 
 def cancel_all():
@@ -644,7 +647,7 @@ try:
             transfer_balances()
             cancel_all()
             loan_all()
-            log.refreshStatus(stringify_total_lended(), get_max_duration())
+            log.refreshStatus(stringify_total_lended(), get_max_duration("status"))
             log.persistStatus()
             sys.stdout.flush()
             time.sleep(sleep_time)

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -285,12 +285,12 @@ def create_loan_offer(currency, amt, rate):
             days = '2'
         if config.has_option('BOT', 'endDate'):
             days_remaining = get_max_duration("order")
-            if days_remaining <= "2":
+            if int(days_remaining) <= 2:
                 print "endDate reached. Bot can no longer lend.\nExiting..."
                 log.log("endDate reached. Bot can no longer lend. Exiting.")
                 exit(0)
             if days > days_remaining:
-                days = days_remaining
+                days = str(days_remaining)
         if not dry_run:
             msg = bot.createLoanOffer(currency, amt, days, 0, rate)
             log.offer(amt, currency, rate, days, msg)
@@ -374,19 +374,19 @@ def get_on_order_balances():
 
 
 def get_max_duration(context):
-    if not config.get('BOT', 'endDate'):
+    if not config.has_option('BOT', 'endDate'):
         return ""
     try:
         now_time = datetime.date.today()
         config_date = map(int, config.get('BOT', 'endDate').split(','))
         end_time = datetime.date(*config_date)  # format YEAR,MONTH,DAY all ints, also used splat operator
         diff_days = (end_time - now_time).days
+        if context == "order":
+            return diff_days  # Order needs int
+        if context == "status":
+            return " - Days Remaining: " + str(diff_days)  # Status needs string
     except Exception as E:
         print "ERROR: There is something wrong with your endDate option. Error: " + str(E)
-    if context == "order":
-        return diff_days
-    if context == "status":
-        return " - Days Remaining: " + diff_days
 
 
 def cancel_all():

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -284,14 +284,14 @@ def create_loan_offer(currency, amt, rate):
         if xday_threshold == 0:
             days = '2'
         if config.has_option('BOT', 'endDate'):
-            days_remaining = get_max_duration("order")
+            days_remaining = int(get_max_duration("order"))
             if int(days_remaining) <= 2:
                 print "endDate reached. Bot can no longer lend.\nExiting..."
                 log.log("The end date has almost been reached and the bot can no longer lend. Exiting.")
                 log.refreshStatus(stringify_total_lended(), get_max_duration("status"))
                 log.persistStatus()
                 exit(0)
-            if days > days_remaining:
+            if int(days) > days_remaining:
                 days = str(days_remaining)
         if not dry_run:
             msg = bot.createLoanOffer(currency, amt, days, 0, rate)
@@ -389,6 +389,7 @@ def get_max_duration(context):
             return " - Days Remaining: " + str(diff_days)  # Status needs string
     except Exception as E:
         print "ERROR: There is something wrong with your endDate option. Error: " + str(E)
+        exit(1)
 
 
 def cancel_all():

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -287,7 +287,7 @@ def create_loan_offer(currency, amt, rate):
             days_remaining = get_max_duration("order")
             if int(days_remaining) <= 2:
                 print "endDate reached. Bot can no longer lend.\nExiting..."
-                log.log("endDate reached. Bot can no longer lend. Exiting.")
+                log.log("The end date has almost been reached and the bot can no longer lend. Exiting.")
                 log.refreshStatus(stringify_total_lended(), get_max_duration("status"))
                 log.persistStatus()
                 exit(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows user to add a date on which the bot will make sure all lends are done by.

Counts down the days on webpage, then automatically shuts down once it can no longer lend.

For users who want the bot to be done by a certain date. Recommended to give it 60 day notice so you don't get stuck with any super long lends.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes issue #14 
<!--- Why is this change required? What problem does it solve? -->

## TESTING STAGE
<!--- Test your bot for at least 24 hours for most changes, certain changes may ignore this requirement. -->
Tested with endDate set in the past, not set at all, set in the far future, and set tomorrow. Bot performed as expected in all cases. Bot deactivates at the first attempt to lend after midnight two days before enddate and leaves a message on the webpage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.] (https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [x] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [x] **If my change requires a change to the config, I have updated the config file and command line arguments accordingly.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
