### PR TITLE
Remove autorenew

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Workflow management with Waffle.io
 - Choose any currency to see your profits in, even show how much you are making in USD!
 - Select different lending strategies on a coin-by-coin basis.
 - Run multiple instances of the bot for multiple accounts easily using multiple config files.
-- Automatically enable Poloniex's AutoRenew feature whenever you shut the bot down, so even then your loans can continue.
 - Configure a date you would like your coins back, and watch the bot make sure all your coins are available to be traded or withdrawn at the beginning of that day.
 - And the best feature of all: It is absolutely free!
 

--- a/default.cfg.example
+++ b/default.cfg.example
@@ -43,9 +43,6 @@ xdays = 60
 #Minimum loan size, the minimum size of offers to make, bigger values prevent the bot from loaning small available amounts but reduce loan fragmentation.
 minloansize = 0.001
 
-#AutoRenew - if set to 1 the bot will set the AutoRenew flag for the loans when you stop it (Ctrl+C) and clear the AutoRenew flag when on started
-autorenew = 0
-
 #Keep Stuck Orders - Sometimes an order gets partially filled. When this happens it may leave the remainder of your coin under the set minloansize.
 #If this happens, KeepStuckOrders will keep your order where it is so maybe it can be filled. Otherwise it will be canceled and held until orders expire.
 keepstuckorders = True

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,8 +126,6 @@ Very few situations require you to change these settings.
 - Allowed range: 0.001 and up.
 - If you dislike loan fragmentation, then this will make the minimum for each loan larger.
 
-``autorenew`` If 0, does nothing. If 1, will enable autorenew on loans once the bot closes with CTRL-C.
-
 ``KeepStuckOrders`` If True, keeps orders that are "stuck" in the market instead of canceling them.
 
 - Default value: True

--- a/lendingbot.py
+++ b/lendingbot.py
@@ -32,7 +32,6 @@ Config.init([config_location])
 # Define the variable from the option in the module where you use it.
 api_key = Config.get("API", "apikey", None)
 api_secret = Config.get("API", "secret", None)
-auto_renew = int(Config.get("BOT", "autorenew", None, 0, 1))
 output_currency = Config.get('BOT', 'outputCurrency', 'BTC')
 end_date = Config.get('BOT', 'endDate')
 json_output_enabled = Config.has_option('BOT', 'jsonfile') and Config.has_option('BOT', 'jsonlogsize')
@@ -50,26 +49,6 @@ Data.init(api, log)
 Lending.init(Config, api, log, Data, MaxToLend, dry_run)
 
 
-def set_auto_renew(auto):
-    i = int(0)  # counter
-    try:
-        action = 'Clearing'
-        if auto == 1:
-            action = 'Setting'
-        log.log(action + ' AutoRenew...(Please Wait)')
-        crypto_lended = api.return_active_loans()
-        loans_count = len(crypto_lended["provided"])
-        for item in crypto_lended["provided"]:
-            if int(item["autoRenew"]) != auto:
-                log.refreshStatus('Processing AutoRenew - ' + str(i) + ' of ' + str(loans_count) + ' loans')
-                api.toggle_auto_renew(int(item["id"]))
-                i += 1
-    except KeyboardInterrupt:
-        log.log('Toggled AutoRenew for ' + str(i) + ' loans')
-        raise SystemExit
-    log.log('Toggled AutoRenew for ' + str(i) + ' loans')
-
-
 print 'Welcome to Poloniex Lending Bot'
 # Configure web server
 
@@ -77,10 +56,6 @@ web_server_enabled = Config.get('BOT', 'startWebServer')
 if web_server_enabled:  # Run web server
     import modules.WebServer as WebServer
     WebServer.initialize_web_server(Config)
-
-# if config includes autorenew - start by clearing the current loans
-if auto_renew == 1:
-    set_auto_renew(0)
 
 try:
     while True:
@@ -115,8 +90,6 @@ try:
             time.sleep(Lending.get_sleep_time())
             pass
 except KeyboardInterrupt:
-    if auto_renew == 1:
-        set_auto_renew(1)
     if web_server_enabled:
         WebServer.stop_web_server()
     log.log('bye')


### PR DESCRIPTION
## Description
As Poloniex added a button in their interface for toggling autorenew on all loans this feature isn't needed anymore, it was based on making multiple calls to their service and would take too long.
![image](https://cloud.githubusercontent.com/assets/1645822/20888146/e529a44c-bafd-11e6-86ef-acf85bea070b.png)

Removing this will reduce code complexity.

## TESTING STAGE
Tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] **I have read CONTRIBUTING.md**
- [X] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [X] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [X] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [X] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
