### PR TITLE
fixed display of low values like 1e-7

### DIFF
--- a/www/lendingbot.js
+++ b/www/lendingbot.js
@@ -53,11 +53,9 @@ function updateOutputCurrency(outputCurrency){
 // below zero accuracy will indicate precision after must significat digit
 // strips trailing zeros
 function prettyFloat(value, accuracy) {
-    var precision = Math.round(Math.log10(value));
-    precision = precision < 0 ? Math.abs(precision) + accuracy : accuracy;
-    var multiplier = Math.pow(10, precision);
-    var result = Math.round(value * multiplier) / multiplier;
-    return isNaN(result) ? "0" : parseFloat(result.toFixed(precision));
+  var precision = Math.round(Math.log10(value));
+  var result = precision < 0 ? value.toFixed(Math.min((accuracy - precision), 8)) : value.toFixed(accuracy);
+  return isNaN(result) ? "0" : result.replace(/(?:\.0+|(\.\d+?)0+)$/, "$1");
 }
 
 function printFloat(value, precision) {


### PR DESCRIPTION
Fix issue described in https://github.com/Mikadily/poloniexlendingbot/issues/236

## TESTING STAGE
in progress

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] **I have read CONTRIBUTING.md**
- [x] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [x] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [N/A] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [N/A] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [x] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
