### PR TITLE
Disabled summary scheduler if notify_summary_minutes isn't configured

### DIFF
--- a/default.cfg.example
+++ b/default.cfg.example
@@ -129,7 +129,7 @@ hideCoins = True
 [notifications]
 notify_tx_coins = False
 notify_xday_threshold = False
-notify_summary_minutes = False
+notify_summary_minutes = 0
 notify_caught_exception = False
 
 email = False

--- a/modules/Configuration.py
+++ b/modules/Configuration.py
@@ -135,7 +135,9 @@ def get_notification_config():
     for conf in ['notify_tx_coins', 'notify_xday_threshold', 'email', 'slack', 'telegram']:
         notify_conf[conf] = getboolean('notifications', conf)
 
-    notify_conf['notify_summary_minutes'] = int(get('notifications', 'notify_summary_minutes'))
+    # in order not to break current config, parsing for False
+    notify_summary_minutes = get('notifications', 'notify_summary_minutes')
+    notify_conf['notify_summary_minutes'] = 0 if notify_summary_minutes == 'False' else int(notify_summary_minutes)
 
     if notify_conf['email']:
         for conf in ['email_login_address', 'email_login_password', 'email_smtp_server', 'email_smtp_port',

--- a/modules/Configuration.py
+++ b/modules/Configuration.py
@@ -128,28 +128,26 @@ def get_currencies_list(option):
 
 
 def get_notification_config():
-    notify_conf = {}
-    notify_conf['enable_notifications'] = config.has_section('notifications')
+    notify_conf = {'enable_notifications': config.has_section('notifications')}
     if not notify_conf['enable_notifications']:
         return notify_conf
 
-    for conf in ['notify_tx_coins', 'notify_xday_threshold', 'notify_summary_minutes']:
-        notify_conf[conf] = get('notifications', conf)
+    for conf in ['notify_tx_coins', 'notify_xday_threshold', 'email', 'slack', 'telegram']:
+        notify_conf[conf] = getboolean('notifications', conf)
 
-    notify_conf['email'] = True if get('notifications', 'email') == 'True' else False
+    notify_conf['notify_summary_minutes'] = int(get('notifications', 'notify_summary_minutes'))
+
     if notify_conf['email']:
         for conf in ['email_login_address', 'email_login_password', 'email_smtp_server', 'email_smtp_port',
                      'email_to_addresses']:
             notify_conf[conf] = get('notifications', conf)
         notify_conf['email_to_addresses'] = notify_conf['email_to_addresses'].split(',')
 
-    notify_conf['slack'] = True if get('notifications', 'slack') == 'True' else False
     if notify_conf['slack']:
         for conf in ['slack_token', 'slack_channels']:
             notify_conf[conf] = get('notifications', conf)
         notify_conf['slack_channels'] = notify_conf['slack_channels'].split(',')
 
-    notify_conf['telegram'] = True if get('notifications', 'telegram') == 'True' else False
     if notify_conf['telegram']:
         for conf in ['telegram_bot_id', 'telegram_chat_ids']:
             notify_conf[conf] = get('notifications', conf)

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -73,7 +73,7 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
 
     sleep_time = sleep_time_active  # Start with active mode
 
-    if notify_conf['enable_notifications']:
+    if notify_conf['notify_summary_minutes']:
         scheduler = sched.scheduler(time.time, time.sleep)
         # Wait 10 seconds before firing the first summary notifcation, then use the config time value for future updates
         scheduler.enter(10, 1, notify_summary, (int(notify_conf['notify_summary_minutes']) * 60, ))

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -73,7 +73,7 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
 
     sleep_time = sleep_time_active  # Start with active mode
 
-    if notify_conf['notify_summary_minutes']:
+    if notify_conf['enable_notifications'] and notify_conf['notify_summary_minutes']:
         scheduler = sched.scheduler(time.time, time.sleep)
         # Wait 10 seconds before firing the first summary notifcation, then use the config time value for future updates
         scheduler.enter(10, 1, notify_summary, (notify_conf['notify_summary_minutes'] * 60, ))

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -73,11 +73,12 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
 
     sleep_time = sleep_time_active  # Start with active mode
 
-    scheduler = sched.scheduler(time.time, time.sleep)
-    # Wait 10 seconds before firing the first summary notifcation, then use the config time value for future updates
-    scheduler.enter(10, 1, notify_summary, (int(notify_conf['notify_summary_minutes']) * 60, ))
-    t = threading.Thread(target=scheduler.run)
-    t.start()
+    if notify_conf['enable_notifications']:
+        scheduler = sched.scheduler(time.time, time.sleep)
+        # Wait 10 seconds before firing the first summary notifcation, then use the config time value for future updates
+        scheduler.enter(10, 1, notify_summary, (int(notify_conf['notify_summary_minutes']) * 60, ))
+        t = threading.Thread(target=scheduler.run)
+        t.start()
 
 
 def get_sleep_time():

--- a/modules/Lending.py
+++ b/modules/Lending.py
@@ -76,7 +76,7 @@ def init(cfg, api1, log1, data, maxtolend, dry_run1, analysis, notify_conf1):
     if notify_conf['notify_summary_minutes']:
         scheduler = sched.scheduler(time.time, time.sleep)
         # Wait 10 seconds before firing the first summary notifcation, then use the config time value for future updates
-        scheduler.enter(10, 1, notify_summary, (int(notify_conf['notify_summary_minutes']) * 60, ))
+        scheduler.enter(10, 1, notify_summary, (notify_conf['notify_summary_minutes'] * 60, ))
         t = threading.Thread(target=scheduler.run)
         t.start()
 


### PR DESCRIPTION
Disabled summary scheduler if Notifications aren't configured

## Description
Check if notifications are enabled before running the scheduler thread

## TESTING STAGE


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] **I have read CONTRIBUTING.md**
- [X] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [X] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [N/A] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [N/A] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
