### PR TITLE
Send TCPServer shutdown signal from a separate thread

### DIFF
--- a/modules/WebServer.py
+++ b/modules/WebServer.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import threading
 
 server = None
 web_server_ip = "0.0.0.0"
@@ -68,7 +69,7 @@ def start_web_server():
 def stop_web_server():
     try:
         print "Stopping WebServer"
-        server.shutdown()
+        threading.Thread(target = server.shutdown).start()
     except Exception as ex:
         ex.message = ex.message if ex.message else str(ex)
         print("Failed to stop WebServer: {0}".format(ex.message))


### PR DESCRIPTION
This prevents the webserver from hanging on KeyboardInterrupt

## Description
When attempting to terminate the lending bot with the webserver running, the "Stopping WebServer" message printed and the process failed to terminate for many seconds, sometimes leading to a "Failed to stop WebServer:" message with a stack trace.

## TESTING STAGE
I'm open to suggestions of how to test this. It now exits cleanly for me, but I'm not sure how to add a good unit test for that.

## Types of changes
The source for socketserver has the following comment:
```
def shutdown(self):
    """Stops the serve_forever loop.

    Blocks until the loop has finished. This must be called while
    serve_forever() is running in another thread, or it will
    deadlock.
```
This change just follows through with that advice by sending the shutdown signal in a new thread specifically opened for this purpose.

## Checklist:
<!--- Go over all the following points, they do not all need to be checked when you first make the PR. -->
<!--- Enter N/A in any tickboxes that do not apply to your change. Example: "- [N/A] Blah blah..."
<!--- For us to merge your PR, after approval, ALL OF THESE CHECKBOXES NEED TO BE TICKED -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I have read CONTRIBUTING.md**
- [X] **I fully understand [Github Flow.](https://guides.github.com/introduction/flow/)**
- [X] **My code adheres to the [code style of this project.](https://poloniexlendingbot.readthedocs.io/en/latest/contributing.html)**
- [X] **I have updated the documentation in /docs if I have changed the config, arguments, logic in how the bot works, or anything that understandably needs a documentation change.**
- [X] **I have updated the config file accordingly if my change requires a new configuration setting or changes an existing one.**
- [ ] **I have tested the bot with no issues for 24 continuous hours. If issues were experienced, they have been patched and tested again.**
